### PR TITLE
Remove Gitpod setup section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Task Manager
-
 A simple task manager application built with React and Redux.
 
 ## Features
@@ -13,30 +12,18 @@ A simple task manager application built with React and Redux.
 - npm or yarn
 
 ### Installation
-
 1. Clone the repository:
-
 ```bash
 git clone https://github.com/your-username/task-manager.git
 cd task-manager
 ```
-
 2. Install the dependencies:
-
 ```bash
 npm install
 # yarn install
 ```
-
 3. Run the development server:
-
 ```bash
 npm run start
 # yarn start
 ```
-
-## Gitpod
-
-In the cloud-free development environment where you can directly start coding.
-
-You can use Gitpod in the cloud  [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/DhanushNehru/task-manager/)


### PR DESCRIPTION
Fixes #26

## Summary
Removed all Gitpod-related references, badges, and setup instructions from the README.md file as requested in Issue #26. 

## Changes Made
- Removed the "## Gitpod" section heading
- Removed the Gitpod description text
- Removed the Gitpod badge and link

## Impact
- All other setup instructions remain clear and accurate
- The README is now cleaner and more focused on the core project setup
- No functional changes to the application

## Type of Change
- [x] Documentation Update

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] I have updated the README.md

## Additional Notes
This PR is part of Hacktoberfest 2025. The changes are straightforward and should be easy to review and merge. Thank you for maintaining this open-source project!

#hacktoberfest